### PR TITLE
Remove type BytesConverter, use template arguments for key and value …

### DIFF
--- a/src/node.mo
+++ b/src/node.mo
@@ -1,13 +1,10 @@
 import Types "types";
-import Conversion "conversion";
 import Constants "constants";
 import Utils "utils";
 
-import Text "mo:base/Text";
 import Debug "mo:base/Debug";
 import Buffer "mo:base/Buffer";
 import Array "mo:base/Array";
-import Nat8 "mo:base/Nat8";
 import Nat64 "mo:base/Nat64";
 import Result "mo:base/Result";
 import Order "mo:base/Order";
@@ -19,28 +16,29 @@ module {
   type Buffer<T> = Buffer.Buffer<T>;
   type Order = Order.Order;
   // For convenience: from types module
-  type Entry = Types.Entry;
+  type Entry<K, V> = Types.Entry<K, V>;
   type NodeType = Types.NodeType;
 
   /// A node of a B-Tree.
   ///
-  /// Each node can contain up to `CAPACITY + 1` children, each child is 8 bytes.
-  public class Node(node_type: NodeType, node_identifier: Nat64) {
+  /// Each node can contain up to `CAPACITY + 1` children.
+  public class Node<K, V>(key_order: (K, K) -> Order, node_type: NodeType, node_identifier: Nat64) {
     
     /// Members
-    var entries_ = Buffer.Buffer<Entry>(0);
-    var children_ = Buffer.Buffer<Node>(0);
+    var entries_ = Buffer.Buffer<Entry<K, V>>(0);
+    var children_ = Buffer.Buffer<Node<K, V>>(0);
+    let key_order_ = key_order;
     let node_type_ = node_type;
     let node_identifier_ = node_identifier;
 
     /// Getters
-    public func getEntries() : Buffer<Entry> { entries_; };
-    public func getChildren() : Buffer<Node> { children_; };
+    public func getEntries() : Buffer<Entry<K, V>> { entries_; };
+    public func getChildren() : Buffer<Node<K, V>> { children_; };
     public func getNodeType() : NodeType  { node_type_; };
     public func getIdentifier() : Nat64  { node_identifier_; };
 
     /// Returns the entry with the max key in the subtree.
-    public func getMax() : Entry {
+    public func getMax() : Entry<K, V> {
       switch(node_type_){
         case(#Leaf) {
           // NOTE: a node can never be empty, so this access is safe.
@@ -57,7 +55,7 @@ module {
     };
 
     /// Returns the entry with min key in the subtree.
-    public func getMin() : Entry {
+    public func getMin() : Entry<K, V> {
       switch(node_type_){
         case(#Leaf) {
           // NOTE: a node can never be empty, so this access is safe.
@@ -79,7 +77,7 @@ module {
     };
 
     /// Swaps the entry at index `idx` with the given entry, returning the old entry.
-    public func swapEntry(idx: Nat, entry: Entry) : Entry {
+    public func swapEntry(idx: Nat, entry: Entry<K, V>) : Entry<K, V> {
       let old_entry = entries_.get(idx);
       entries_.put(idx, entry);
       old_entry;
@@ -91,17 +89,17 @@ module {
     /// of the matching key. If the value is not found then `Result::Err` is
     /// returned, containing the index where a matching key could be inserted
     /// while maintaining sorted order.
-    public func getKeyIdx(key: [Nat8]) : Result<Nat, Nat> {
-      Utils.binarySearch(getKeys(), compareEntryKeys, key);
+    public func getKeyIdx(key: K) : Result<Nat, Nat> {
+      Utils.binarySearch(getKeys(), key_order_, key);
     };
 
     /// Get the child at the given index. Traps if the index is superior than the number of children.
-    public func getChild(idx: Nat) : Node {
+    public func getChild(idx: Nat) : Node<K, V> {
       children_.get(idx);
     };
 
     /// Get the entry at the given index. Traps if the index is superior than the number of entries.
-    public func getEntry(idx: Nat) : Entry {
+    public func getEntry(idx: Nat) : Entry<K, V> {
       entries_.get(idx);
     };
 
@@ -114,101 +112,74 @@ module {
     };
 
     /// Set the node's children
-    public func setChildren(children: Buffer<Node>) {
+    public func setChildren(children: Buffer<Node<K, V>>) {
       children_ := children;
     };
 
     /// Set the node's entries
-    public func setEntries(entries: Buffer<Entry>) {
+    public func setEntries(entries: Buffer<Entry<K, V>>) {
       entries_ := entries;
     };
 
     /// Add a child at the end of the node's children.
-    public func addChild(child: Node) {
+    public func addChild(child: Node<K, V>) {
       children_.add(child);
     };
 
     /// Add an entry at the end of the node's entries.
-    public func addEntry(entry: Entry) {
+    public func addEntry(entry: Entry<K, V>) {
       entries_.add(entry);
     };
 
     /// Set the child at given index
-    public func setChild(idx: Nat, child: Node) {
+    public func setChild(idx: Nat, child: Node<K, V>) {
       children_.put(idx, child);
     };
 
     /// Remove the child at the end of the node's children.
-    public func popChild() : ?Node {
+    public func popChild() : ?Node<K, V> {
       children_.removeLast();
     };
 
     /// Remove the entry at the end of the node's entries.
-    public func popEntry() : ?Entry {
+    public func popEntry() : ?Entry<K, V> {
       entries_.removeLast();
     };
 
     /// Insert a child into the node's children at the given index.
-    public func insertChild(idx: Nat, child: Node) {
+    public func insertChild(idx: Nat, child: Node<K, V>) {
       Utils.insert(children_, idx, child);
     };
 
     /// Insert an entry into the node's entries at the given index.
-    public func insertEntry(idx: Nat, entry: Entry) {
+    public func insertEntry(idx: Nat, entry: Entry<K, V>) {
       Utils.insert(entries_, idx, entry);
     };
 
     /// Remove the child from the node's children at the given index.
-    public func removeChild(idx: Nat) : Node {
+    public func removeChild(idx: Nat) : Node<K, V> {
       Utils.remove(children_, idx);
     };
 
     /// Remove the entry from the node's entries at the given index.
-    public func removeEntry(idx: Nat) : Entry {
+    public func removeEntry(idx: Nat) : Entry<K, V> {
       Utils.remove(entries_, idx);
     };
 
     /// Append the given children to the node's children
-    public func appendChildren(children: Buffer<Node>) {
+    public func appendChildren(children: Buffer<Node<K, V>>) {
       children_.append(children);
     };
 
     /// Append the given entries to the node's entries
-    public func appendEntries(entries: Buffer<Entry>) {
+    public func appendEntries(entries: Buffer<Entry<K, V>>) {
       entries_.append(entries);
     };
 
-    func getKeys() : [[Nat8]] {
-      Array.map(entries_.toArray(), func(entry: Entry) : [Nat8] { entry.0; });
+    func getKeys() : [K] {
+      Array.map(entries_.toArray(), func(entry: Entry<K, V>) : K { entry.0; });
     };
 
-    public func entriesToText() : Text {
-      let text_buffer = Buffer.Buffer<Text>(0);
-      text_buffer.add("Entries = [");
-      for ((key, val) in entries_.vals()){
-        text_buffer.add("e([");
-        for (byte in Array.vals(key)){
-          text_buffer.add(Nat8.toText(byte) # " ");
-        };
-        text_buffer.add("], [");
-        for (byte in Array.vals(val)){
-          text_buffer.add(Nat8.toText(byte) # " ");
-        };
-        text_buffer.add("]), ");
-      };
-      text_buffer.add("]");
-      Text.join("", text_buffer.vals());
-    };
-
-  };
-
-  public func makeEntry(key: [Nat8], value: [Nat8]) : Entry {
-    (key, value);
-  };
-
-  /// Compare the two entries using their keys
-  public func compareEntryKeys(key_a: [Nat8], key_b: [Nat8]) : Order {
-    Utils.lexicographicallyCompare(key_a, key_b, Nat8.compare);
   };
 
   /// The maximum number of entries per node.

--- a/src/types.mo
+++ b/src/types.mo
@@ -1,20 +1,17 @@
 import Result "mo:base/Result";
 import Buffer "mo:base/Buffer";
+import Order "mo:base/Order";
 
 module {
 
   // For convenience: from base module
   type Result<Ok, Err> = Result.Result<Ok, Err>;
   type Buffer<T> = Buffer.Buffer<T>;
-
-  public type BytesConverter<T> = {
-    fromBytes: ([Nat8]) -> T;
-    toBytes: (T) -> [Nat8];
-  };
+  type Order = Order.Order;
 
   /// An indicator of the current position in the map.
-  public type Cursor = {
-    node: INode;
+  public type Cursor<K, V> = {
+    node: INode<K, V>;
     next: Index;
   };
 
@@ -29,54 +26,52 @@ module {
   };
 
   // Entries in the node are key-value pairs and both are blobs.
-  public type Entry = ([Nat8], [Nat8]);
+  public type Entry<K ,V> = (K, V);
 
   public type NodeType = {
     #Leaf;
     #Internal;
   };
 
-  public type INode = {
-    getEntries: () -> Buffer<Entry>;
-    getChildren: () -> Buffer<INode>;
+  public type INode<K, V> = {
+    getEntries: () -> Buffer<Entry<K, V>>;
+    getChildren: () -> Buffer<INode<K, V>>;
     getNodeType: () -> NodeType;
     getIdentifier: () -> Nat64;
-    getMax: () -> Entry;
-    getMin: () -> Entry;
+    getMax: () -> Entry<K, V>;
+    getMin: () -> Entry<K, V>;
     isFull: () -> Bool;
-    swapEntry: (Nat, Entry) -> Entry;
-    getKeyIdx: ([Nat8]) -> Result<Nat, Nat>;
-    getChild: (Nat) -> INode;
-    getEntry: (Nat) -> Entry;
+    swapEntry: (Nat, Entry<K, V>) -> Entry<K, V>;
+    getKeyIdx: (K) -> Result<Nat, Nat>;
+    getChild: (Nat) -> INode<K, V>;
+    getEntry: (Nat) -> Entry<K, V>;
     getChildrenIdentifiers : () -> [Nat64];
-    setChildren: (Buffer<INode>) -> ();
-    setEntries: (Buffer<Entry>) -> ();
-    setChild: (Nat, INode) -> ();
-    addChild: (INode) -> ();
-    addEntry: (Entry) -> ();
-    popEntry: () -> ?Entry;
-    popChild: () -> ?INode;
-    insertChild: (Nat, INode) -> ();
-    insertEntry: (Nat, Entry) -> ();
-    removeChild: (Nat) -> INode;
-    removeEntry: (Nat) -> Entry;
-    appendChildren: (Buffer<INode>) -> ();
-    appendEntries: (Buffer<Entry>) -> ();
-    entriesToText: () -> Text;
+    setChildren: (Buffer<INode<K, V>>) -> ();
+    setEntries: (Buffer<Entry<K, V>>) -> ();
+    setChild: (Nat, INode<K, V>) -> ();
+    addChild: (INode<K, V>) -> ();
+    addEntry: (Entry<K, V>) -> ();
+    popEntry: () -> ?Entry<K, V>;
+    popChild: () -> ?INode<K, V>;
+    insertChild: (Nat, INode<K, V>) -> ();
+    insertEntry: (Nat, Entry<K, V>) -> ();
+    removeChild: (Nat) -> INode<K, V>;
+    removeEntry: (Nat) -> Entry<K, V>;
+    appendChildren: (Buffer<INode<K, V>>) -> ();
+    appendEntries: (Buffer<Entry<K, V>>) -> ();
   };
 
   public type IBTreeMap<K, V> = {
-    getRootNode : () -> INode;
-    getKeyConverter : () -> BytesConverter<K>;
-    getValueConverter : () -> BytesConverter<V>;
+    getRootNode : () -> INode<K, V>;
     getLength : () -> Nat64;
+    getKeyOrder : () -> ((K, K) -> Order);
     insert : (k: K, v: V) -> ?V;
     get : (key: K) -> ?V;
     containsKey : (key: K) -> Bool;
     isEmpty : () -> Bool;
     remove : (key: K) -> ?V;
     iter : () -> IIter<K, V>;
-    range : ([Nat8], ?[Nat8]) -> IIter<K, V>;
+    range : (K, K) -> IIter<K, V>;
   };
 
 };

--- a/test/module/testIter.mo
+++ b/test/module/testIter.mo
@@ -1,25 +1,29 @@
 import BTreeMap "../../src/btreemap";
 import Node "../../src/node";
+import Utils "../../src/utils";
 import TestableItems "testableItems";
 
 import Iter "mo:base/Iter";
 import Nat64 "mo:base/Nat64";
 import Nat8 "mo:base/Nat8";
 import Int "mo:base/Int";
+import Order "mo:base/Order";
 
 module {
-
+  
+  // For convenience: from base modules
+  type Order = Order.Order;
   // For convenience: from other modules
   type TestBuffer = TestableItems.TestBuffer;
 
-  let bytes_passtrough = {
-      fromBytes = func(bytes: [Nat8]) : [Nat8] { bytes; };
-      toBytes = func(bytes: [Nat8]) : [Nat8] { bytes; };
-    };
-
+  /// Compare two bytes
+  func bytesOrder(a: [Nat8], b: [Nat8]) : Order {
+    Utils.lexicographicallyCompare(a, b, Nat8.compare);
+  };
+  
   func iterateLeaf(test: TestBuffer) {
     
-    let btree = BTreeMap.BTreeMap<[Nat8], [Nat8]>(bytes_passtrough, bytes_passtrough);
+    let btree = BTreeMap.BTreeMap<[Nat8], [Nat8]>(bytesOrder);
 
     for (i in Iter.range(0, Nat64.toNat(Node.getCapacity() - 1))){
       ignore btree.insert([Nat8.fromNat(i)], [Nat8.fromNat(i + 1)]);
@@ -37,7 +41,7 @@ module {
 
   func iterateChildren(test: TestBuffer) {
 
-    let btree = BTreeMap.BTreeMap<[Nat8], [Nat8]>(bytes_passtrough, bytes_passtrough);
+    let btree = BTreeMap.BTreeMap<[Nat8], [Nat8]>(bytesOrder);
 
     // Insert the elements in reverse order.
     for (i in Iter.revRange(99, 0)){

--- a/test/module/testableItems.mo
+++ b/test/module/testableItems.mo
@@ -28,7 +28,8 @@ module {
   let { run;test;suite; } = Suite;
   // For convenience: from types module
   type NodeType = Types.NodeType;
-  type Entry = Types.Entry;
+  type BytesEntry = Types.Entry<[Nat8], [Nat8]>;
+  type NatEntry = Types.Entry<Nat, Nat>;
 
   func testNat(item: Nat) : Testable.TestableItem<Nat> {
     { display = Nat.toText; equals = Nat.equal; item ; };
@@ -161,6 +162,10 @@ module {
     testOptItem<[Nat8]>(item, bytesToText, bytesEqual);
   };
 
+  func testOptNat(item: ?Nat) : Testable.TestableItem<?Nat> {
+    testOptItem<Nat>(item, Nat.toText, Nat.equal);
+  };
+
   func testNodeType(node_type: NodeType) : Testable.TestableItem<NodeType> {
     {
       display = func(node_type: NodeType) : Text {
@@ -188,27 +193,53 @@ module {
     };
   };
 
-  func entryToText(entry: Entry) : Text {
+  func bytesEntryToText(entry: BytesEntry) : Text {
     "key: " # bytesToText(entry.0) # ", value: " # bytesToText(entry.1);
   };
 
-  func entryEqual(entry1: Entry, entry2: Entry) : Bool {
+  func bytesEntryEqual(entry1: BytesEntry, entry2: BytesEntry) : Bool {
     bytesEqual(entry1.0, entry2.0) and bytesEqual(entry1.1, entry2.1);
   };
 
-  func testEntries(entries: [Entry]) : Testable.TestableItem<[Entry]> {
+  func testBytesEntries(entries: [BytesEntry]) : Testable.TestableItem<[BytesEntry]> {
     {
-      display = func(entries: [Entry]) : Text {
+      display = func(entries: [BytesEntry]) : Text {
         let text_buffer = Buffer.Buffer<Text>(entries.size() + 2);
         text_buffer.add("[");
         for (entry in Array.vals(entries)){
-          text_buffer.add("(" # entryToText(entry) # "), ");
+          text_buffer.add("(" # bytesEntryToText(entry) # "), ");
         };
         text_buffer.add("]");
         Text.join("", text_buffer.vals());
       };
-      equals = func(entries1: [Entry], entries2: [Entry]) : Bool {
-        Array.equal(entries1, entries2, entryEqual);
+      equals = func(entries1: [BytesEntry], entries2: [BytesEntry]) : Bool {
+        Array.equal(entries1, entries2, bytesEntryEqual);
+      };
+      item = entries;
+    };
+  };
+
+  func natEntryToText(entry: NatEntry) : Text {
+    "key: " # Nat.toText(entry.0) # ", value: " # Nat.toText(entry.1);
+  };
+
+  func natEntryEqual(entry1: NatEntry, entry2: NatEntry) : Bool {
+    Nat.equal(entry1.0, entry2.0) and Nat.equal(entry1.1, entry2.1);
+  };
+
+  func testNatEntries(entries: [NatEntry]) : Testable.TestableItem<[NatEntry]> {
+    {
+      display = func(entries: [NatEntry]) : Text {
+        let text_buffer = Buffer.Buffer<Text>(entries.size() + 2);
+        text_buffer.add("[");
+        for (entry in Array.vals(entries)){
+          text_buffer.add("(" # natEntryToText(entry) # "), ");
+        };
+        text_buffer.add("]");
+        Text.join("", text_buffer.vals());
+      };
+      equals = func(entries1: [NatEntry], entries2: [NatEntry]) : Bool {
+        Array.equal(entries1, entries2, natEntryEqual);
       };
       item = entries;
     };
@@ -292,6 +323,10 @@ module {
       equals<?[Nat8]>("equalsOptBytes", actual, testOptBytes(expected));
     };
 
+    public func equalsOptNat(actual: ?Nat, expected: ?Nat){
+      equals<?Nat>("equalsOptNat", actual, testOptNat(expected));
+    };
+
     public func equalsNodeType(actual: NodeType, expected: NodeType){
       equals<NodeType>("equalsNodeType", actual, testNodeType(expected));
     };
@@ -300,8 +335,12 @@ module {
       equals<Bool>("equalsBool", actual, testBool(expected));
     };
 
-    public func equalsEntries(actual: [Entry], expected: [Entry]){
-      equals<[Entry]>("equalsEntries", actual, testEntries(expected));
+    public func equalsBytesEntries(actual: [BytesEntry], expected: [BytesEntry]){
+      equals<[BytesEntry]>("equalsBytesEntries", actual, testBytesEntries(expected));
+    };
+
+    public func equalsNatEntries(actual: [NatEntry], expected: [NatEntry]){
+      equals<[NatEntry]>("equalsNatEntries", actual, testNatEntries(expected));
     };
 
     public func equalsOptArrayNat16(actual: ?[Nat16], expected: ?[Nat16]){


### PR DESCRIPTION
…instead. Use lower_bound and upper_bound instead of prefix and offset for range function. Adapt tests in consequence.