### PR TITLE
WIP: reduce allocations by refactoring

### DIFF
--- a/src/modules/btreemap.mo
+++ b/src/modules/btreemap.mo
@@ -1,6 +1,6 @@
 import Types      "types";
 import Allocator  "allocator";
-import Conversion "conversion";
+
 import Node       "node";
 import Constants  "constants";
 import Iter       "iter";
@@ -18,6 +18,8 @@ import Nat64      "mo:base/Nat64";
 import Order      "mo:base/Order";
 import Buffer     "mo:base/Buffer";
 import Nat8       "mo:base/Nat8";
+
+// TODO crusso: consider never loading/saving _buffer field (assuming it's just reserve space).
 
 module {
 

--- a/src/modules/btreemap.mo
+++ b/src/modules/btreemap.mo
@@ -975,14 +975,13 @@ module {
     };
 
     func allocateNode(node_type: NodeType) : Node {
-      Node.Node({
-        address = allocator_.allocate();
-        entries = [];
-        children = [];
-        node_type;
-        max_key_size = max_key_size_;
-        max_value_size = max_value_size_;
-      });
+      Node.Node(
+        allocator_.allocate(),
+        [],
+        [],
+        node_type,
+        max_key_size_,
+        max_value_size_)
     };
 
     public func loadNode(address: Address) : Node {

--- a/src/modules/conversion.mo
+++ b/src/modules/conversion.mo
@@ -14,10 +14,14 @@ import Text      "mo:base/Text";
 import Int       "mo:base/Int";
 import Array     "mo:base/Array";
 
+// TODO: Use (new) direct conversions, not via Nat, make little-endian
+// TODO: Use blob indexing once available (avoiding intermediate arrays).
+// TODO: Use direct blob conversion, once available.
+
 module {
 
   // Comes from Candy library conversion.mo: https://raw.githubusercontent.com/skilesare/candy_library/main/src/conversion.mo
-  
+
   //////////////////////////////////////////////////////////////////////
   // The following functions converst standard types to Byte arrays
   // From there you can easily get to blobs if necessary with the Blob package
@@ -75,14 +79,22 @@ module {
   };
 
   public func bytesToNat16(bytes: Blob) : Nat16{
-
     let array = Blob.toArray(bytes);
     (Nat16.fromNat(Nat8.toNat(array[0])) << 8) +
     (Nat16.fromNat(Nat8.toNat(array[1])));
   };
 
-  public func byteArrayToNat32(array: [Nat8]) : Nat32{
+  public func bytesToNat8(bytes: Blob) : Nat8{
+    let array = Blob.toArray(bytes);
+    array[0]
+  };
 
+  /// Returns Blob of size 4 of the Nat16
+  public func nat8ToBytes(x : Nat8) : Blob {
+    Blob.fromArray([x]);
+  };
+
+  public func byteArrayToNat32(array: [Nat8]) : Nat32{
     (Nat32.fromNat(Nat8.toNat(array[0])) << 24) +
     (Nat32.fromNat(Nat8.toNat(array[1])) << 16) +
     (Nat32.fromNat(Nat8.toNat(array[2])) << 8) +
@@ -99,7 +111,6 @@ module {
   };
 
   public func bytesToNat64(bytes: Blob) : Nat64{
-    
     let array = Blob.toArray(bytes);
     (Nat64.fromNat(Nat8.toNat(array[0])) << 56) +
     (Nat64.fromNat(Nat8.toNat(array[1])) << 48) +

--- a/src/modules/conversion.mo
+++ b/src/modules/conversion.mo
@@ -191,6 +191,8 @@ module {
     };
   };
 
+  // crusso: what does this function do? It's certainly not decoding utf8 to Text but looks
+  // like its decoding a binary sequence of 4-byte (unencoded) Unicode codepoints ?
   public func bytesToText(_bytes : Blob) : Text{
     
     let array = Blob.toArray(_bytes);

--- a/src/modules/conversion.mo
+++ b/src/modules/conversion.mo
@@ -221,6 +221,14 @@ module {
     return Principal.fromBlob(_bytes);
   };
 
+  public func boolToByte(_bool : Bool) : Nat8 {
+    if _bool 1 else 0
+  };
+
+  public func byteToBool(byte : Nat8) : Bool{
+    byte != 0;
+  };
+
   public func boolToBytes(_bool : Bool) : Blob {
     
     if(_bool == true){

--- a/src/modules/memory.mo
+++ b/src/modules/memory.mo
@@ -12,7 +12,6 @@ import Debug     "mo:base/Debug";
 import Iter      "mo:base/Iter";
 import Text      "mo:base/Text";
 import Nat8      "mo:base/Nat8";
-import Result    "mo:base/Result";
 
 import Conversion "conversion";
 
@@ -20,8 +19,6 @@ module {
 
   // For convenience: from types module
   type Memory = Types.Memory;
-  // For convenience: from base module
-  type Result<Ok, Err> = Result.Result<Ok, Err>;
 
   type GrowFailed = {
     current_size: Nat64;

--- a/src/modules/memory.mo
+++ b/src/modules/memory.mo
@@ -95,7 +95,7 @@ module {
   };
 
   /// Reads the Nat64 bytes at the specified address, traps if exceeds memory size.
-  public func read64(memory: Memory, address: Nat64) : Nat64 {
+  public func readNat64(memory: Memory, address: Nat64) : Nat64 {
     memory.loadNat64(address);
   };
 

--- a/src/modules/memory.mo
+++ b/src/modules/memory.mo
@@ -52,27 +52,25 @@ module {
     memory.write(address, bytes);
   };
 
-/*
-  public func writeNat8(memory: Memory, address: Nat64, bytes: Nat8) {
+
+  public func writeNat8(memory: Memory, address: Nat64, v: Nat8) {
     prepWrite(memory, address, 1);
-    memory.storeNat8(address, bytes);
+    memory.storeNat8(address, v);
   };
-*/
 
-  public func writeNat16(memory: Memory, address: Nat64, bytes: Nat16) {
+  public func writeNat16(memory: Memory, address: Nat64, v: Nat16) {
     prepWrite(memory, address, 2);
-    memory.storeNat16(address, bytes);
+    memory.storeNat16(address, v);
   };
 
-  public func writeNat32(memory: Memory, address: Nat64, bytes: Nat32) {
+  public func writeNat32(memory: Memory, address: Nat64, v: Nat32) {
     prepWrite(memory, address, 4);
-    memory.storeNat32(address, bytes);
+    memory.storeNat32(address, v);
   };
 
-
-  public func writeNat64(memory: Memory, address: Nat64, bytes: Nat64) {
+  public func writeNat64(memory: Memory, address: Nat64, v: Nat64) {
     prepWrite(memory, address, 8);
-    memory.storeNat64(address, bytes);
+    memory.storeNat64(address, v);
   };
 
 
@@ -81,7 +79,12 @@ module {
     memory.read(address, size);
   };
 
-  /// Reads the Nat32 bytes at the specified address, traps if exceeds memory size.
+  /// Reads the Nat8 bytes at the specified address, traps if exceeds memory size.
+  public func readNat8(memory: Memory, address: Nat64) : Nat8 {
+    memory.loadNat8(address);
+  };
+
+  /// Reads the Nat16 bytes at the specified address, traps if exceeds memory size.
   public func readNat16(memory: Memory, address: Nat64) : Nat16 {
     memory.loadNat16(address);
   };
@@ -114,26 +117,28 @@ module {
     public func read(address: Nat64, size: Nat) : Blob {
       Region.loadBlob(r, address, size);
     };
-/*
+
     public func storeNat8(address: Nat64, v: Nat8) {
       Region.storeNat8(r, address, v);
     };
     public func loadNat8(address: Nat64) : Nat8 {
-      Region.loadNat8(r, address, size);
+      Region.loadNat8(r, address);
     };
-*/
+
     public func storeNat16(address: Nat64, v: Nat16) {
       Region.storeNat16(r, address, v);
     };
     public func loadNat16(address: Nat64) : Nat16 {
       Region.loadNat16(r, address);
     };
+
     public func storeNat32(address: Nat64, v: Nat32) {
       Region.storeNat32(r, address, v);
     };
     public func loadNat32(address: Nat64) : Nat32 {
       Region.loadNat32(r, address);
     };
+
     public func storeNat64(address: Nat64, v: Nat64) {
       Region.storeNat64(r, address, v);
     };
@@ -208,7 +213,7 @@ module {
       Text.join("", text_buffer.vals());
     };
 
-/*
+
     public func storeNat8(address: Nat64, v: Nat8) {
       write(address, Conversion.nat8ToBytes(v));
     };
@@ -216,7 +221,7 @@ module {
     public func loadNat8(address: Nat64) : Nat8 {
       Conversion.bytesToNat8(read(address, 1));
     };
-*/
+
     public func storeNat16(address: Nat64, v: Nat16) {
       write(address, Conversion.nat16ToBytes(v));
     };

--- a/src/modules/memory.mo
+++ b/src/modules/memory.mo
@@ -14,6 +14,8 @@ import Text      "mo:base/Text";
 import Nat8      "mo:base/Nat8";
 import Result    "mo:base/Result";
 
+import Conversion "conversion";
+
 module {
 
   // For convenience: from types module
@@ -81,6 +83,33 @@ module {
     public func read(address: Nat64, size: Nat) : Blob {
       Region.loadBlob(r, address, size);
     };
+/*
+    public func storeNat8(address: Nat64, v: Nat8) {
+      Region.storeNat8(r, address, v);
+    };
+    public func loadNat8(address: Nat64) : Nat8 {
+      Region.loadNat8(r, address, size);
+    };
+*/
+    public func storeNat16(address: Nat64, v: Nat16) {
+      Region.storeNat16(r, address, v);
+    };
+    public func loadNat16(address: Nat64) : Nat16 {
+      Region.loadNat16(r, address);
+    };
+    public func storeNat32(address: Nat64, v: Nat32) {
+      Region.storeNat32(r, address, v);
+    };
+    public func loadNat32(address: Nat64) : Nat32 {
+      Region.loadNat32(r, address);
+    };
+    public func storeNat64(address: Nat64, v: Nat64) {
+      Region.storeNat64(r, address, v);
+    };
+    public func loadNat64(address: Nat64) : Nat64 {
+      Region.loadNat64(r, address);
+    };
+
   };
 
   public class VecMemory() = this {
@@ -147,6 +176,40 @@ module {
       text_buffer.add("]");
       Text.join("", text_buffer.vals());
     };
+
+/*
+    public func storeNat8(address: Nat64, v: Nat8) {
+      write(address, Conversion.nat8ToBytes(v));
+    };
+
+    public func loadNat8(address: Nat64) : Nat8 {
+      Conversion.bytesToNat8(read(address, 1));
+    };
+*/
+    public func storeNat16(address: Nat64, v: Nat16) {
+      write(address, Conversion.nat16ToBytes(v));
+    };
+
+    public func loadNat16(address: Nat64) : Nat16 {
+      Conversion.bytesToNat16(read(address, 2));
+    };
+
+    public func storeNat32(address: Nat64, v: Nat32) {
+      write(address, Conversion.nat32ToBytes(v));
+    };
+
+    public func loadNat32(address: Nat64) : Nat32 {
+      Conversion.bytesToNat32(read(address, 4));
+    };
+
+    public func storeNat64(address: Nat64, v: Nat64) {
+      write(address, Conversion.nat64ToBytes(v));
+    };
+
+    public func loadNat64(address: Nat64) : Nat64 {
+      Conversion.bytesToNat64(read(address, 8));
+    };
+
 
   };
 

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -76,22 +76,28 @@ module {
           (key, value)
         }
     );
-    // Load children if this is an internal 
-    var children = Buffer.Buffer<Address>(0);
+    // Load children if this is an internal
+    let children =
     if (header.node_type == INTERNAL_NODE_TYPE) {
       // The number of children is equal to the number of entries + 1.
-      for (_ in Iter.range(0, Nat16.toNat(header.num_entries))){
-        let child = Conversion.bytesToNat64(Memory.read(memory, address + offset, ADDRESS_SIZE));
-        offset += Nat64.fromNat(ADDRESS_SIZE);
-        children.add(child);
-      };
+      let children =
+        Array.tabulate<Address>(Nat16.toNat(header.num_entries+1),
+        func _ {
+          let child = Conversion.bytesToNat64(Memory.read(memory, address + offset, ADDRESS_SIZE));
+          offset += Nat64.fromNat(ADDRESS_SIZE);
+          child;
+        }
+      );
       assert(children.size() == entries.size() + 1);
+      children;
+    } else {
+      []
     };
 
     Node({
       address;
       entries;
-      children = Buffer.toArray(children);
+      children;
       node_type = getNodeType(header);
       max_key_size;
       max_value_size;

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -81,7 +81,8 @@ module {
     if (header.node_type == INTERNAL_NODE_TYPE) {
       // The number of children is equal to the number of entries + 1.
       let children =
-        Array.tabulate<Address>(Nat16.toNat(header.num_entries+1),
+        Array.tabulate<Address>(Nat16.toNat(header.num_entries)+1,
+
         func _ {
           let child = Conversion.bytesToNat64(Memory.read(memory, address + offset, ADDRESS_SIZE));
           offset += Nat64.fromNat(ADDRESS_SIZE);

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -53,28 +53,29 @@ module {
     if (header.version != LAYOUT_VERSION)                     { Debug.trap("Unsupported version."); };
 
     // Load the entries.
-    var entries = Buffer.Buffer<Entry>(0);
     var offset = SIZE_NODE_HEADER;
-    for (_ in Iter.range(0, Nat16.toNat(header.num_entries - 1))){
-      // Read the key's size.
-      let key_size = Memory.readNat32(memory, address + offset);
-      offset += U32_SIZE;
+    let entries =
+      Array.tabulate<Entry>(Nat16.toNat(header.num_entries),
+        func _ {
+          // Read the key's size.
+          let key_size = Memory.readNat32(memory, address + offset);
+          offset += U32_SIZE;
 
-      // Read the key.
-      let key = Memory.read(memory, address + offset, Nat32.toNat(key_size));
-      offset += Nat64.fromNat(Nat32.toNat(max_key_size));
+          // Read the key.
+          let key = Memory.read(memory, address + offset, Nat32.toNat(key_size));
+          offset += Nat64.fromNat(Nat32.toNat(max_key_size));
 
-      // Read the value's size.
-      let value_size = Memory.readNat32(memory, address + offset);
-      offset += U32_SIZE;
+          // Read the value's size.
+          let value_size = Memory.readNat32(memory, address + offset);
+          offset += U32_SIZE;
 
-      // Read the value.
-      let value = Memory.read(memory, address + offset, Nat32.toNat(value_size));
-      offset += Nat64.fromNat(Nat32.toNat(max_value_size));
+          // Read the value.
+          let value = Memory.read(memory, address + offset, Nat32.toNat(value_size));
+          offset += Nat64.fromNat(Nat32.toNat(max_value_size));
 
-      entries.add((key, value));
-    };
-
+          (key, value)
+        }
+    );
     // Load children if this is an internal 
     var children = Buffer.Buffer<Address>(0);
     if (header.node_type == INTERNAL_NODE_TYPE) {
@@ -89,7 +90,7 @@ module {
 
     Node({
       address;
-      entries = Buffer.toArray(entries);
+      entries;
       children = Buffer.toArray(children);
       node_type = getNodeType(header);
       max_key_size;

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -84,7 +84,7 @@ module {
         Array.tabulate<Address>(Nat16.toNat(header.num_entries)+1,
 
         func _ {
-          let child = Conversion.bytesToNat64(Memory.read(memory, address + offset, ADDRESS_SIZE));
+          let child = Memory.readNat64(memory, address + offset);
           offset += Nat64.fromNat(ADDRESS_SIZE);
           child;
         }

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -203,7 +203,7 @@ module {
         offset += Nat64.fromNat(Nat32.toNat(max_key_size_));
 
         // Write the size of the value.
-        Memory.writeNat32(memory, address_ + offset,Nat32.fromNat(value.size()));
+        Memory.writeNat32(memory, address_ + offset, Nat32.fromNat(value.size()));
         offset += Nat64.fromNat(U32_SIZE);
 
         // Write the value.

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -94,14 +94,14 @@ module {
       []
     };
 
-    Node({
-      address;
-      entries;
-      children;
-      node_type = getNodeType(header);
-      max_key_size;
-      max_value_size;
-    });
+    Node(
+      address,
+      entries,
+      children,
+      getNodeType(header),
+      max_key_size,
+      max_value_size
+    );
   };
 
   /// Returns the size of a node in bytes.
@@ -142,15 +142,21 @@ module {
   ///     - value (`max_value_size` bytes)
   ///
   /// Each node can contain up to `CAPACITY + 1` children, each child is 8 bytes.
-  public class Node(variables : NodeVariables) {
+  public class Node(
+    address: Address,
+    entries: [Entry],
+    children: [Address],
+    node_type: NodeType,
+    max_key_size: Nat32,
+    max_value_size: Nat32) {
     
     /// Members
-    var address_ : Address = variables.address;
-    var entries_ : Buffer<Entry> = Utils.toBuffer(variables.entries);
-    var children_ : Buffer<Address> = Utils.toBuffer(variables.children);
-    let node_type_ : NodeType = variables.node_type;
-    let max_key_size_ : Nat32 = variables.max_key_size;
-    let max_value_size_ : Nat32 = variables.max_value_size;
+    var address_ : Address = address;
+    var entries_ : Buffer<Entry> = Utils.toBuffer(entries);
+    var children_ : Buffer<Address> = Utils.toBuffer(children);
+    let node_type_ : NodeType = node_type;
+    let max_key_size_ : Nat32 = max_key_size;
+    let max_value_size_ : Nat32 = max_value_size;
 
     /// Getters
     public func getAddress() : Address { address_; };

--- a/src/modules/node.mo
+++ b/src/modules/node.mo
@@ -57,7 +57,7 @@ module {
     var offset = SIZE_NODE_HEADER;
     for (_ in Iter.range(0, Nat16.toNat(header.num_entries - 1))){
       // Read the key's size.
-      let key_size = Conversion.bytesToNat32(Memory.read(memory, address + offset, U32_SIZE));
+      let key_size = Memory.readNat32(memory, address + offset);
       offset += Nat64.fromNat(U32_SIZE);
 
       // Read the key.
@@ -65,7 +65,7 @@ module {
       offset += Nat64.fromNat(Nat32.toNat(max_key_size));
 
       // Read the value's size.
-      let value_size = Conversion.bytesToNat32(Memory.read(memory, address + offset, U32_SIZE));
+      let value_size = Memory.readNat32(memory, address + offset);
       offset += Nat64.fromNat(U32_SIZE);
 
       // Read the value.
@@ -189,13 +189,13 @@ module {
       };
 
       saveNodeHeader(header, address_, memory);
-      
+
       var offset = SIZE_NODE_HEADER;
 
       // Write the entries.
       for ((key, value) in entries_.vals()) {
         // Write the size of the key.
-        Memory.write(memory, address_ + offset, Conversion.nat32ToBytes(Nat32.fromNat(key.size())));
+        Memory.writeNat32(memory, address_ + offset, Nat32.fromNat(key.size()));
         offset += Nat64.fromNat(U32_SIZE);
 
         // Write the key.
@@ -203,7 +203,7 @@ module {
         offset += Nat64.fromNat(Nat32.toNat(max_key_size_));
 
         // Write the size of the value.
-        Memory.write(memory, address_ + offset, Conversion.nat32ToBytes(Nat32.fromNat(value.size())));
+        Memory.writeNat32(memory, address_ + offset,Nat32.fromNat(value.size()));
         offset += Nat64.fromNat(U32_SIZE);
 
         // Write the value.
@@ -213,7 +213,7 @@ module {
 
       // Write the children
       for (child in children_.vals()){
-        Memory.write(memory, address_ + offset, Conversion.nat64ToBytes(child));
+        Memory.writeNat64(memory, address_ + offset, child);
         offset += Nat64.fromNat(ADDRESS_SIZE); // Address size
       };
     };

--- a/src/modules/types.mo
+++ b/src/modules/types.mo
@@ -29,8 +29,9 @@ module {
     loadNat16: Nat64 -> Nat16;
     storeNat16: (Nat64, Nat16) -> ();
     loadNat32: Nat64 -> Nat32;
-    storeNat64: (Nat64, Nat64) -> ();
+    storeNat32: (Nat64, Nat32) -> ();
     loadNat64: Nat64 -> Nat64;
+    storeNat64: (Nat64, Nat64) -> ();
   };
 
   /// An indicator of the current position in the map.

--- a/src/modules/types.mo
+++ b/src/modules/types.mo
@@ -22,6 +22,15 @@ module {
     grow: (Nat64) -> Int64;
     write: (Nat64, Blob) -> ();
     read: (Nat64, Nat) -> Blob;
+    /*
+    storeNat8: (Nat64, Nat8) -> ();
+    loadNat8: Nat64 -> Nat8;
+    */
+    loadNat16: Nat64 -> Nat16;
+    storeNat16: (Nat64, Nat16) -> ();
+    loadNat32: Nat64 -> Nat32;
+    storeNat64: (Nat64, Nat64) -> ();
+    loadNat64: Nat64 -> Nat64;
   };
 
   /// An indicator of the current position in the map.

--- a/src/modules/types.mo
+++ b/src/modules/types.mo
@@ -22,10 +22,8 @@ module {
     grow: (Nat64) -> Int64;
     write: (Nat64, Blob) -> ();
     read: (Nat64, Nat) -> Blob;
-    /*
     storeNat8: (Nat64, Nat8) -> ();
     loadNat8: Nat64 -> Nat8;
-    */
     loadNat16: Nat64 -> Nat16;
     storeNat16: (Nat64, Nat16) -> ();
     loadNat32: Nat64 -> Nat32;

--- a/test/integration/package-lock.json
+++ b/test/integration/package-lock.json
@@ -10,7 +10,7 @@
         "bip39": "^3.0.4",
         "hdkey": "^2.0.1",
         "isomorphic-fetch": "^3.0.0",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "^3.3.2",
         "tape": "^5.6.1"
       }
     },
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
       }
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -1827,9 +1827,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
     "deep-equal": {
       "version": "2.0.5",
@@ -2368,9 +2368,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -6,6 +6,7 @@
     "bip39": "^3.0.4",
     "hdkey": "^2.0.1",
     "isomorphic-fetch": "^3.0.0",
+    "node-fetch": "^3.3.2",
     "tape": "^5.6.1"
   }
 }


### PR DESCRIPTION
This PR attempts to increase performance using type specific load/store operations on Regions, avoiding expensive intermediate Blob allocations.

Warning: when using Regions, the scalar data will now be written in (Wasm natural)  little-endian format, not big-endian as in the original code. Please shout if that matters.

I've only specialized some read/writes so far, more to come. Hence draft and  WIP.

- [x] re-measure perf
- [x] Optimize entry reading using Array.tabulate
- [ ] Use new fixed-size conversions where possible
- [ ] Consider deleting alignment and reservation fields (or at least not load/saving them)
- [ ] Consider statically switching between regions and vector memory using package arguments/compiler flags, avoiding indirection.
- [ ] Avoid blob allocation when checking magic numbers (if poss)

# Perf numbers (using old cost model)

Before
https://github.com/dfinity/canister-profiling/pull/94
![image](https://github.com/sardariuss/MotokoStableBTree/assets/85788/7f74b51d-3004-454a-9863-eaa5e1a766bf)

After
![image](https://github.com/sardariuss/MotokoStableBTree/assets/85788/3b4d6ade-a4d0-44da-b86c-e4678dccc443)
https://github.com/dfinity/canister-profiling/pull/95

Seems to indicate a 50% decrease in cycle costs.

@sardariuss what do you think?